### PR TITLE
Fix Tidal login by updating Electron to v35.1.1+wvcus

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@typescript-eslint/parser": "^7.0.2",
     "@vercel/webpack-asset-relocator-loader": "^1.7.3",
     "css-loader": "^6.6.0",
-    "electron": "https://github.com/castlabs/electron-releases#v29.0.1+wvcus",
+    "electron": "https://github.com/castlabs/electron-releases#v35.1.1+wvcus",
     "electron-installer-dmg": "^4.0.0",
     "electron-osx-sign": "0.6.0",
     "eslint": "^7.6.0",


### PR DESCRIPTION
Resolves authentication issues where login button was unresponsive. Updated from v29.0.1+wvcus while maintaining Widevine DRM support.